### PR TITLE
Add query to app.transition.

### DIFF
--- a/src/pypercard/__about__.py
+++ b/src/pypercard/__about__.py
@@ -18,4 +18,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-__version__ = "0.0.1.alpha.8"
+__version__ = "0.0.1.alpha.9"

--- a/src/pypercard/core.py
+++ b/src/pypercard/core.py
@@ -216,18 +216,9 @@ class Card:
         html = self.template.format(**self.app.datastore)
         self.content.innerHTML = html
 
-        # Set an auto-advance timer if required.
+        # Start an auto-advance timer if required.
         if self.auto_advance is not None:
-
-            def on_timeout():
-                """Called when the card timer has timed-out!"""
-
-                self.app.machine.next({"event": "timeout", "card": self})
-
-            # Python sleeps in seconds, JavaScript in milliseconds :)
-            self._auto_advance_timer = setTimeout(
-                ffi.create_proxy(on_timeout), int(self.auto_advance * 1000)
-            )
+            self._start_auto_advance_timer()
 
         # Add DOM event listeners for any transitions added via
         # "app.transition".
@@ -274,6 +265,21 @@ class Card:
                 element.addEventListener(
                     transition["dom_event_name"], transition["handler"]
                 )
+
+    def _start_auto_advance_timer(self):
+        """
+        Start the card's auto-advance timer.
+        """
+
+        def on_timeout():
+            """Called when the card timer has timed-out!"""
+
+            self.app.machine.next({"event": "timeout", "card": self})
+
+        # Python sleeps in seconds, JavaScript in milliseconds :)
+        self._auto_advance_timer = setTimeout(
+            ffi.create_proxy(on_timeout), int(self.auto_advance * 1000)
+        )
 
     def hide(self):
         """

--- a/src/pypercard/core.py
+++ b/src/pypercard/core.py
@@ -218,6 +218,7 @@ class Card:
 
         # Set an auto-advance timer if required.
         if self.auto_advance is not None:
+
             def on_timeout():
                 """Called when the card timer has timed-out!"""
 
@@ -261,8 +262,11 @@ class Card:
                 target_elements = self.get_elements(transition["selector"])
 
             for element in target_elements:
+
                 def handler(evt):
-                    self.app.machine.next({"event": evt.type, "dom_event": evt})
+                    self.app.machine.next(
+                        {"event": evt.type, "dom_event": evt}
+                    )
 
                 handler_proxy = ffi.create_proxy(handler)
                 transition["handler"] = handler_proxy
@@ -702,7 +706,9 @@ class App:
         if not keep_place:
             sound.currentTime = 0
 
-    def register_transition(self, dom_event_name, element_id=None, selector=None):
+    def register_transition(
+        self, dom_event_name, element_id=None, selector=None
+    ):
         """
         `event_name` - e.g. "click"
         `element_id` - the unique ID identifying the target element.
@@ -857,8 +863,12 @@ class App:
         )
 
     def _create_dom_event_transition(
-        self, from_card_name, transition_fn_or_card_name, dom_event_name,
-        element_id=None, selector=None
+        self,
+        from_card_name,
+        transition_fn_or_card_name,
+        dom_event_name,
+        element_id=None,
+        selector=None,
     ):
         """
         Create a transition that is triggered by a DOM event.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -751,7 +751,9 @@ def test_app_transition_with_query():
     expected element/event happens on an element that matches the specified
     query.
     """
-    tc1 = pypercard.Card("test_card1", "<button class='press-me'>Click me</button>")
+    tc1 = pypercard.Card(
+        "test_card1", "<button class='press-me'>Click me</button>"
+    )
     tc2 = pypercard.Card("test_card2", "<p>Finished!</p>")
     app = pypercard.App(cards=[tc1, tc2])
 
@@ -861,8 +863,12 @@ def test_app_transition_on_all_cards_with_query():
     A function decorated by the @app.transition works correctly when the
     expected element/event happens on all cards.
     """
-    tc1 = pypercard.Card("test_card1", '<button class="next">Click me</button>')
-    tc2 = pypercard.Card("test_card2", '<button class="next">Click me</button>')
+    tc1 = pypercard.Card(
+        "test_card1", '<button class="next">Click me</button>'
+    )
+    tc2 = pypercard.Card(
+        "test_card2", '<button class="next">Click me</button>'
+    )
     tc3 = pypercard.Card("test_card3", "<p>Finished!</p>")
     app = pypercard.App(cards=[tc1, tc2, tc3])
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -915,6 +915,28 @@ def test_app_start():
     assert app_placeholder.firstChild == tc1.content
 
 
+def test_app_start_with_no_arguments():
+    """
+    Assuming the app is configured correctly, calling start with no arguments
+    results in the first card in the list being rendered to the DOM.
+    """
+    tc1 = pypercard.Card("test_card1", "<button id='id1'>Click me</button>")
+    tc2 = pypercard.Card("test_card2", "<p>Finished!</p>")
+    app = pypercard.App(cards=[tc1, tc2])
+
+    mock_work = mock.MagicMock()
+
+    @app.transition(tc1, "click", id="id1")
+    def my_transition(app, card):
+        mock_work(app, card)
+        return "test_card2"
+
+    app.start()
+
+    app_placeholder = document.querySelector("pyper-app")
+    assert app_placeholder.firstChild == tc1.content
+
+
 def test_app_start_already_started():
     """
     If the app is already started, calling start will result in a

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -721,7 +721,7 @@ def test_app_transition_decorator_missing_card():
             pass
 
 
-def test_app_transition_on_element_id():
+def test_app_transition_with_element_id():
     """
     A function decorated by the @app.transition works correctly when the
     expected element/event happens on the element with the specified id.
@@ -739,6 +739,31 @@ def test_app_transition_on_element_id():
 
     app.start("test_card1")
     button = tc1.get_element("#id1")
+    button.click()
+    assert call_count.call_count == 1
+    assert tc1.content.style.display == "none"
+    assert tc2.content.innerHTML == "<p>Finished!</p>"
+
+
+def test_app_transition_with_query():
+    """
+    A function decorated by the @app.transition works correctly when the
+    expected element/event happens on an element that matches the specified
+    query.
+    """
+    tc1 = pypercard.Card("test_card1", "<button class='press-me'>Click me</button>")
+    tc2 = pypercard.Card("test_card2", "<p>Finished!</p>")
+    app = pypercard.App(cards=[tc1, tc2])
+
+    call_count = mock.MagicMock()
+
+    @app.transition("test_card1", "click", query=".press-me")
+    def my_transition(app, card):
+        call_count()
+        return "test_card2"
+
+    app.start()
+    button = tc1.get_element(".press-me")
     button.click()
     assert call_count.call_count == 1
     assert tc1.content.style.display == "none"
@@ -794,6 +819,68 @@ def test_app_transition_on_multiple_cards():
     assert tc2.content.innerHTML == '<button id="id2">Click me</button>'
 
     button = tc2.get_element("#id2")
+    button.click()
+    assert call_count.call_count == 2
+    assert tc2.content.style.display == "none"
+    assert tc3.content.innerHTML == "<p>Finished!</p>"
+
+
+def test_app_transition_on_all_cards():
+    """
+    A function decorated by the @app.transition works correctly when the
+    expected element/event happens on all cards.
+    """
+    tc1 = pypercard.Card("test_card1", '<button id="id1">Click me</button>')
+    tc2 = pypercard.Card("test_card2", '<button id="id2">Click me</button>')
+    tc3 = pypercard.Card("test_card3", "<p>Finished!</p>")
+    app = pypercard.App(cards=[tc1, tc2, tc3])
+
+    call_count = mock.MagicMock()
+
+    @app.transition("*", "click")
+    def my_transition(app, card):
+        call_count()
+        return "+"
+
+    app.start("test_card1")
+    button = tc1.get_element("#id1")
+    button.click()
+    assert call_count.call_count == 1
+    assert tc1.content.style.display == "none"
+    assert tc2.content.innerHTML == '<button id="id2">Click me</button>'
+
+    button = tc2.get_element("#id2")
+    button.click()
+    assert call_count.call_count == 2
+    assert tc2.content.style.display == "none"
+    assert tc3.content.innerHTML == "<p>Finished!</p>"
+
+
+def test_app_transition_on_all_cards_with_query():
+    """
+    A function decorated by the @app.transition works correctly when the
+    expected element/event happens on all cards.
+    """
+    tc1 = pypercard.Card("test_card1", '<button class="next">Click me</button>')
+    tc2 = pypercard.Card("test_card2", '<button class="next">Click me</button>')
+    tc3 = pypercard.Card("test_card3", "<p>Finished!</p>")
+    app = pypercard.App(cards=[tc1, tc2, tc3])
+
+    call_count = mock.MagicMock()
+
+    @app.transition("*", "click", query=".next")
+    def my_transition(app, card):
+        call_count()
+        return "+"
+
+    app.start("test_card1")
+    button = tc1.get_element(".next")
+    button.click()
+    assert call_count.call_count == 1
+    assert tc1.content.style.display == "none"
+    assert tc2.content.innerHTML == '<button class="next">Click me</button>'
+
+    button = tc2.get_element(".next")
     button.click()
     assert call_count.call_count == 2
     assert tc2.content.style.display == "none"


### PR DESCRIPTION
Warning: there is some duplication in registering DOM events now that this PR fixes the "*" card wildcard so they can take
a query... I suggest we fix that in another PR as it is time for a cleanup sweep...

This allows you to use a CSS query selector in app.transition:-

@app.transition("card-x", "click" ".next")
def some_function(app, card):
  ...
  
The "*" wildcard now works correctly so you can use selectors there too e.g. for a generic "next" transition...

@app.transition("*", "click" ".next")
def some_function(app, card):
  return "+"
